### PR TITLE
Show last caption on missing end of file separator

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,24 +6,33 @@ var utf8 = require('to-utf-8')
 module.exports = function () {
   var buf = []
 
+  var convert = function () {
+    return buf.join('\r\n')
+      .replace(/\{\\([ibu])\}/g, '</$1>')
+      .replace(/\{\\([ibu])1\}/g, '<$1>')
+      .replace(/\{([ibu])\}/g, '<$1>')
+      .replace(/\{\/([ibu])\}/g, '</$1>')
+      .replace(/(\d\d:\d\d:\d\d),(\d\d\d)/g, '$1.$2') + '\r\n\r\n'
+  }
+
   var write = function (line, enc, cb) {
     if (line.trim()) {
       buf.push(line.trim())
       return cb()
     }
 
-    line = buf.join('\r\n')
-      .replace(/\{\\([ibu])\}/g, '</$1>')
-      .replace(/\{\\([ibu])1\}/g, '<$1>')
-      .replace(/\{([ibu])\}/g, '<$1>')
-      .replace(/\{\/([ibu])\}/g, '</$1>')
-      .replace(/(\d\d:\d\d:\d\d),(\d\d\d)/g, '$1.$2') + '\r\n\r\n'
+    line = convert()
 
     buf = []
     cb(null, line)
   }
 
-  var parse = through.obj(write)
+  var flush = function (cb) {
+    if (buf.length) this.push(convert())
+    cb()
+  }
+
+  var parse = through.obj(write, flush)
   parse.push('WEBVTT FILE\r\n\r\n')
   return pumpify(utf8({newline: false, detectSize: 4095}), split(), parse)
 }

--- a/test/test.js
+++ b/test/test.js
@@ -39,3 +39,13 @@ tape('latin1 encoding', function (t) {
     t.end()
   }))
 })
+
+tape('missing file ending CRLF', function (t) {
+  var convert = srt2vtt()
+  convert.write('1\r\n00:00:10,500 --> 00:00:13,000\r\nthis is a test\r\n\r\n2\r\n00:00:14,500 --> 00:00:15,000\r\nthis is a test\r\n')
+  convert.end()
+  convert.pipe(concat(function (data) {
+    t.same(data.toString(), 'WEBVTT FILE\r\n\r\n1\r\n00:00:10.500 --> 00:00:13.000\r\nthis is a test\r\n\r\n2\r\n00:00:14.500 --> 00:00:15.000\r\nthis is a test\r\n\r\n')
+    t.end()
+  }))
+})


### PR DESCRIPTION
This fixes #4 and handles the edge case, writing last subtitle line on missing (optional) end of file separator. 